### PR TITLE
feat: update website content to accurately reflect Force Field product

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       <a href="#home" class="nav__logo">Force Field</a>
       <ul class="nav__links" role="list">
         <li><a href="#home" class="nav__link">Home</a></li>
-        <li><a href="#about" class="nav__link">About</a></li>
+        <li><a href="#about" class="nav__link">Features</a></li>
         <li><a href="#contact" class="nav__link">Contact</a></li>
       </ul>
     </nav>
@@ -28,39 +28,39 @@
     <!-- Hero -->
     <section id="home" class="hero">
       <div class="hero__content">
-        <h1 class="hero__headline">Build Without Limits</h1>
+        <h1 class="hero__headline">Ship Code on Autopilot</h1>
         <p class="hero__subtext">
-          Force Field is an open-source project dedicated to making the web faster, simpler, and more expressive — one iteration at a time.
+          Force Field is an AI-powered Kanban board where Claude Code autonomously picks up GitHub issues, completes development work in cloud environments, and delivers pull requests — so your team can focus on what matters.
         </p>
-        <a href="#about" class="btn btn--primary">Learn More</a>
+        <a href="#about" class="btn btn--primary">See How It Works</a>
       </div>
     </section>
 
     <!-- About -->
     <section id="about" class="about">
       <div class="container">
-        <h2 class="section-title">About Force Field</h2>
+        <h2 class="section-title">How Force Field Works</h2>
         <div class="about__grid">
           <div class="about__text">
             <p>
-              Force Field is a lean, purposeful web project built from the ground up with plain HTML, CSS, and JavaScript. No frameworks, no bloat — just clean, standards-based code that any browser can run.
+              GitHub issues become Kanban cards. Claude Code claims them, spins up a GitHub Codespace, writes the code, and opens a pull request — all without manual intervention. The board tracks every step from Backlog to Done.
             </p>
             <p>
-              The project is developed incrementally, issue by issue, with a focus on craft, clarity, and simplicity. Every feature is deliberate; every line of code has a reason to exist.
+              A configurable confidence framework keeps humans in the loop. When the agent is uncertain, it pauses in a Needs Discovery column and waits for guidance before continuing. You stay in control without babysitting every task.
             </p>
           </div>
           <div class="about__features">
             <div class="feature-card">
-              <h3 class="feature-card__title">Lightweight</h3>
-              <p class="feature-card__desc">Zero dependencies. Pure browser-native technologies that load instantly and run everywhere.</p>
+              <h3 class="feature-card__title">Autonomous</h3>
+              <p class="feature-card__desc">Claude Code picks up todo tasks, executes in GitHub Codespaces, and delivers pull requests without manual intervention.</p>
             </div>
             <div class="feature-card">
-              <h3 class="feature-card__title">Open Source</h3>
-              <p class="feature-card__desc">Fully open on GitHub. Explore the code, open issues, and contribute to the project's direction.</p>
+              <h3 class="feature-card__title">GitHub Native</h3>
+              <p class="feature-card__desc">Two-way sync keeps your board and GitHub in perfect alignment. Issues, PRs, CI results, and labels all update automatically.</p>
             </div>
             <div class="feature-card">
-              <h3 class="feature-card__title">Iterative</h3>
-              <p class="feature-card__desc">Built one focused change at a time. Incremental development that keeps quality high and scope tight.</p>
+              <h3 class="feature-card__title">Human in the Loop</h3>
+              <p class="feature-card__desc">A configurable confidence framework determines when the agent acts vs. pauses for review — keeping you in control.</p>
             </div>
           </div>
         </div>
@@ -71,7 +71,7 @@
     <section id="contact" class="contact">
       <div class="container container--narrow">
         <h2 class="section-title">Get in Touch</h2>
-        <p class="contact__intro">Have a question, idea, or want to contribute? Send a message and we'll get back to you.</p>
+        <p class="contact__intro">Have a question, idea, or want to contribute to Force Field? Send a message and we'll get back to you.</p>
         <form class="contact-form" novalidate>
           <div class="form-group">
             <label class="form-label" for="name">Name</label>


### PR DESCRIPTION
## Summary

- Updated hero headline from "Build Without Limits" to "Ship Code on Autopilot" to accurately describe what Force Field does
- Updated hero subtext to describe Force Field as an AI-powered Kanban board where Claude Code autonomously picks up GitHub issues, executes in Codespaces, and delivers PRs
- Replaced the generic "About Force Field" section with "How Force Field Works" — accurate copy drawn from the Force Field CLAUDE.md
- Replaced three feature cards (Lightweight / Open Source / Iterative) with product-accurate cards: **Autonomous**, **GitHub Native**, **Human in the Loop**
- Updated nav label "About" → "Features" to better describe the section content
- Maintained the existing marketing tone throughout

## Test plan

- [ ] Open `index.html` in a browser and verify all three sections render correctly
- [ ] Confirm hero headline reads "Ship Code on Autopilot"
- [ ] Confirm three feature cards show Autonomous, GitHub Native, Human in the Loop
- [ ] Confirm nav link "Features" scrolls to the about/features section
- [ ] Confirm footer GitHub link still points to the correct repo

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)